### PR TITLE
Wrap config services starting with % and @ in quotes

### DIFF
--- a/development/extensions/modification_to_extension.rst
+++ b/development/extensions/modification_to_extension.rst
@@ -151,16 +151,16 @@ definition of the newspage controller service would be something similar to:
          nickvergessen.newspage.controller:
              class: nickvergessen\newspage\controller\main
              arguments:
-                 - @auth
-                 - @cache
-                 - @config
-                 - @dbal.conn
-                 - @request
-                 - @template
-                 - @user
-                 - @controller.helper
-                 - %core.root_path%
-                 - %core.php_ext%
+                 - '@auth'
+                 - '@cache'
+                 - '@config'
+                 - '@dbal.conn'
+                 - '@request'
+                 - '@template'
+                 - '@user'
+                 - '@controller.helper'
+                 - '%core.root_path%'
+                 - '%core.php_ext%'
 
 Any service that is previously defined in your file, or in the file of the phpBB
 core ``phpBB/config/services.yml``, can also be used as an argument, aswell as
@@ -741,9 +741,9 @@ This is done using the ``event.listener`` tag in the ``config/service.yml``:
     nickvergessen.newspage.listener:
         class: nickvergessen\newspage\event\main_listener
         arguments:
-            - @controller.helper
-            - @template
-            - @user
+            - '@controller.helper'
+            - '@template'
+            - '@user'
         tags:
             - { name: event.listener }
 

--- a/development/extensions/tutorial_controllers.rst
+++ b/development/extensions/tutorial_controllers.rst
@@ -110,10 +110,10 @@ should look as follows:
         acme.demo.controller:
             class: acme\demo\controller\main
             arguments:
-                - @config
-                - @controller.helper
-                - @template
-                - @user
+                - '@config'
+                - '@controller.helper'
+                - '@template'
+                - '@user'
         acme.demo.listener:
             class: acme\demo\event\main_listener
             tags:
@@ -251,8 +251,8 @@ We also have to extend the definition of the listener in the
         acme.demo.listener:
             class: acme\demo\event\main_listener
             arguments:
-                - @controller.helper
-                - @template
+                - '@controller.helper'
+                - '@template'
             tags:
                 - { name: event.listener }
 


### PR DESCRIPTION
We should promote the practice of wrapping these in single quotes, as that is preferred by Symfony and will eventually be mandatory (non quoted method is already deprecated)