### PR TITLE
Ext Docs Part 1 - Basics and Events

### DIFF
--- a/development/extensions/tutorial_basics.rst
+++ b/development/extensions/tutorial_basics.rst
@@ -46,7 +46,7 @@ The extension name is the name of the extension. In this tutorial we will use ``
 Composer JSON
 =============
 
-Every extension requires a metadata file named ``composer.json`` in order for phpBB to identify your extension.
+Every extension requires a meta data file named ``composer.json`` in order for phpBB to identify your extension.
 This file contains basic information about an extension as well its dependencies. It is written using the JSON format
 and must be stored in the root folder of the extension, e.g.: ``phpBB/ext/acme/demo/composer.json``.
 
@@ -160,8 +160,7 @@ extra
 -----
 
 This section can contain virtually any arbitrary data according to the composer-specification. However, phpBB requires
- two
-special entries in this array for extensions:
+two special entries in this array for extensions:
 
 .. csv-table::
    :header: "Field", "Content"

--- a/development/extensions/tutorial_basics.rst
+++ b/development/extensions/tutorial_basics.rst
@@ -121,7 +121,7 @@ The details of the meta data are explained below the sample, but for now let's h
 authors
 -------
 
-You may have unlimited authors. At least have one author is highly recommended.
+You may have unlimited authors. At least one author is highly recommended.
 
 .. csv-table::
    :header: "Field", "Content"

--- a/development/extensions/tutorial_basics.rst
+++ b/development/extensions/tutorial_basics.rst
@@ -9,8 +9,8 @@ Welcome to phpBB's official extension tutorial and documentation.
 
 These tutorial pages are based on phpBB's `Acme Demo <https://github.com/phpbb/phpbb-ext-acme-demo>`_ extension. This
 simple extension demonstrates many common features of an extension, including using a front-controller page, modifying
-phpBB through core events and template events, modifying the database using migrations, and installing an ACP module
-with configuration settings.
+phpBB through core events and template events, modifying the database using migrations, and setting up an ACP module
+for configuration settings.
 
 This tutorial covers the basic creation of extensions:
 
@@ -19,7 +19,7 @@ This tutorial covers the basic creation of extensions:
 
 .. seealso::
 
-    The :doc:`skeleton_extension` is a fantastic tool to help developers rapidly generate the initial
+    The :doc:`skeleton_extension` is a tool to help developers rapidly generate the initial
     files and components needed to start developing new extensions for phpBB.
 
 
@@ -30,9 +30,9 @@ All extensions must be located within the ``ext/`` folder which can be found in 
 
 Extensions are packaged using a folder structure as follows: ``vendor/extname``.
 
-Thus, an extension should be located in the phpBB directory as follows: ``phpBB/ext/vendor/extname``
+Thus, an extension should be located in the phpBB directory as follows: ``phpBB/ext/vendor/extname``.
 
-The vendor name can be the author's username or any other name you choose to group your extensions with.
+The vendor name can be the author's username or any other name you choose to group your extensions by.
 The extension name is the name of the extension. In this tutorial we will use ``acme`` as the vendor name and
 ``demo`` as the extension name.
 
@@ -48,7 +48,7 @@ Composer JSON
 
 Every extension requires a meta data file named ``composer.json`` in order for phpBB to identify your extension.
 This file contains basic information about an extension as well its dependencies. It is written using the JSON format
-and must be stored in the root folder of the extension, e.g.: ``phpBB/ext/acme/demo/composer.json``.
+and must be stored in the root folder of the extension, e.g. ``phpBB/ext/acme/demo/composer.json``.
 
 The information in ``composer.json`` will be used by the Extensions Manager in the ACP.
 The details of the meta data are explained below the sample, but for now let's have a look at the complete file:
@@ -59,7 +59,7 @@ The details of the meta data are explained below the sample, but for now let's h
         "name": "acme/demo",
         "type": "phpbb-extension",
         "description": "Acme Demo Extension for phpBB 3.1",
-        "homepage": "https://github.com/nickvergessen/phpbb-ext-acme-demo",
+        "homepage": "https://github.com/phpbb/phpbb-ext-acme-demo",
         "version": "0.1.0",
         "time": "2013-11-05",
         "keywords": ["phpbb", "extension", "acme", "demo"],
@@ -92,30 +92,30 @@ The details of the meta data are explained below the sample, but for now let's h
     It is important to remember that the last item or object in any JSON array must not contain a trailing comma.
 
 .. csv-table::
-   :header: "Field", "Content"
+   :header: "Field", "Required", "Content"
    :delim: |
 
-   ``name`` | "The vendor name and extension name, separated by ``/``, matching the folder
+   ``name`` | Yes | "The vendor name and extension name, separated by ``/``, matching the folder
    structure."
-   ``type`` | "The type of package. It should always be ``phpbb-extension``."
-   ``description`` | "A short description of your extension, may be empty
+   ``type`` | Yes | "The type of package. It should always be ``phpbb-extension``."
+   ``description`` | Yes | "A short description of your extension, may be empty
    (but not skipped)."
-   ``homepage`` *optional* | "A valid URL. It is recommended to use the link
+   ``homepage`` | No | "A valid URL. It is recommended to use the link
    to the contribution in the customisation database, or to the repository of
    your extension (if you are using a public one like GitHub)."
-   ``version`` | "The version of your extension. This should follow the format of X.Y.Z with an optional suffix
+   ``version`` | Yes | "The version of your extension. This should follow the format of X.Y.Z with an optional suffix
    of -dev, -patch, -alpha, -beta or -RC."
-   ``time`` *optional* | "The release date of your extension. Must be in YYYY-MM-DD or YYYY-MM-DD HH:MM:SS format."
-   ``keywords`` *optional* | "An array of keywords related to the extension."
-   ``license`` | "The license of the package. This can be either a string or an array of strings.
+   ``time`` | No | "The release date of your extension. Must be in YYYY-MM-DD or YYYY-MM-DD HH:MM:SS format."
+   ``keywords`` | No | "An array of keywords related to the extension."
+   ``license`` | Yes | "The license of the package. This can be either a string or an array of strings.
    Typically extensions should be licensed under the same GPL-2.0 license as phpBB."
-   ``authors`` | "An array of authors of the extension.
+   ``authors`` | Yes | "An array of authors of the extension.
    See `authors`_ for more details."
-   ``require`` | "An array of requirements of the extension.
+   ``require`` | Yes | "An array of requirements of the extension.
    See `require`_ for more details."
-   ``require-dev`` *optional* | "An array of development requirements of the extension.
+   ``require-dev`` | No | "An array of development requirements of the extension.
    See `require-dev`_ for more details."
-   ``extra`` | "An array of arbitrary extra data.
+   ``extra`` | Yes | "An array of arbitrary extra data.
    See `extra`_ for more details."
 
 authors
@@ -124,19 +124,19 @@ authors
 You may have unlimited authors. At least one author is highly recommended.
 
 .. csv-table::
-   :header: "Field", "Content"
+   :header: "Field", "Required", "Content"
    :delim: |
 
-   ``name`` | "The name of an author."
-   ``email`` *optional* | "An email address of the author."
-   ``homepage`` *optional* | "A URL pointing to the website of the author."
-   ``role`` *optional* | "Role can be used to specify what the author did for the
+   ``name`` | Yes | "The name of an author."
+   ``email`` | No | "An email address of the author."
+   ``homepage`` | No | "A URL pointing to the website of the author."
+   ``role`` | No | "Role can be used to specify what the author did for the
    extension (e.g. Developer, Translator, Supporter, etc.)"
 
 require
 -------
 
-List the dependencies required by the extension, i.e: the PHP version and
+List the dependencies required by the extension, i.e. the PHP version and
 `third party libraries <https://packagist.org/>`_.
 
 .. csv-table::
@@ -159,14 +159,14 @@ the newest version, we require ``dev-master``.
 extra
 -----
 
-This section can contain virtually any arbitrary data according to the composer-specification. However, phpBB requires
+This section can contain virtually any arbitrary data according to the composer specification. However, phpBB requires
 two special entries in this array for extensions:
 
 .. csv-table::
    :header: "Field", "Content"
    :delim: |
 
-   ``display-name`` | "The name of your extension, e.g.: Acme Demo Extension."
+   ``display-name`` | "The name of your extension, e.g. Acme Demo Extension."
    ``soft-require`` | "The minimum-stability version of phpBB required by the extension. In this case we require
    any 3.1 version, which is done by prefixing it with a ``~``: ``""phpbb/phpbb"": ""~3.1""``."
 
@@ -176,5 +176,5 @@ two special entries in this array for extensions:
 
     More information on specifying package version constraints can be found here: https://getcomposer.org/doc/articles/versions.md#basic-constraints
 
-So far, your extension has no functionality yet. Continue on to the next sections to learn more about how to write
+So far, our extension has no functionality yet. Continue on to the next sections to learn more about how to write
 an extension that will do something useful.

--- a/development/extensions/tutorial_basics.rst
+++ b/development/extensions/tutorial_basics.rst
@@ -145,7 +145,7 @@ List the dependencies required by the extension, i.e: the PHP version and
 
    ``php`` | "The minimum-stability version of PHP required by the extension. phpBB 3.1 requires PHP 5.3.3 or higher,
    so the version comparison is ``>= 5.3.3``."
-   ``composer/installers`` | "Recommended by phpBB for some internal handling."
+   ``composer/installers`` | "Recommended by phpBB. This will install extensions to the correct location in phpBB when installed via Composer."
 
 require-dev
 -----------

--- a/development/extensions/tutorial_basics.rst
+++ b/development/extensions/tutorial_basics.rst
@@ -36,7 +36,7 @@ The vendor name can be the author's username or any other name you choose to gro
 The extension name is the name of the extension. In this tutorial we will use ``acme`` as the vendor name and
 ``demo`` as the extension name.
 
-.. warning::
+.. important::
 
     Both the vendor and extension names must start with a lower or upper case letter, followed by letters and numbers
     only. **Underscores, dashes and other characters are not permitted.** It is perfectly fine to have an extension

--- a/development/extensions/tutorial_basics.rst
+++ b/development/extensions/tutorial_basics.rst
@@ -1,47 +1,57 @@
-===========================
-Tutorial: Basics and Events
-===========================
+=========================
+Tutorial: Getting Started
+=========================
 
 Introduction
 ============
 
-This tutorial explains the basic functionality of extensions:
+Welcome to phpBB's official extension tutorial and documentation.
 
- * Basics: `Extension folder`_ and `composer.json`_
- * `HTML Events`_
- * `PHP Events`_
+These tutorial pages are based on phpBB's `Acme Demo <https://github.com/phpbb/phpbb-ext-acme-demo>`_ extension. This
+simple extension demonstrates many common features of an extension, including using a front-controller page, modifying
+phpBB through core events and template events, modifying the database using migrations, and installing an ACP module
+with configuration settings.
+
+This tutorial covers the basic creation of extensions:
+
+ * `Extension folder`_
+ * `Composer JSON`_
 
 .. seealso::
 
-   If you know modifications from phpBB 3.0, you may also have a look at
-   :doc:`modification_to_extension` which helps you to transform your
-   modification into an extension step by step.
+    The :doc:`skeleton_extension` is a fantastic tool to help developers rapidly generate the initial
+    files and components needed to start developing new extensions for phpBB.
 
-Extension folder
+
+Extension Folder
 ================
 
-The first thing you need to do, in order to make phpBB aware of your extension,
-is to create a ``composer.json``. The file needs to be in a subfolder of the
-``ext/`` folder that is shipped with phpBB.
-Inside this folder you need to create a folder with your author (vendor) name.
-Then create the folder of the extension inside the vendor folder.
+All extensions must be located within the ``ext/`` folder which can be found in phpBB's root folder.
 
-.. note::
+Extensions are packaged using a folder structure as follows: ``vendor/extname``.
 
-    Both the vendor and extension folder names must start with a lower or
-    upper case ASCII letter (a to z), followed by ASCII letters and numbers
-    only!
+Thus, an extension should be located in the phpBB directory as follows: ``phpBB/ext/vendor/extname``
 
-In this tutorial we use ``acme`` as vendor name and ``demo`` as extension name.
-So the ``composer.json`` should be located at ``ext/acme/demo/composer.json``.
+The vendor name can be the author's username or any other name you choose to group your extensions with.
+The extension name is the name of the extension. In this tutorial we will use ``acme`` as the vendor name and
+``demo`` as the extension name.
 
-composer.json
+.. warning::
+
+    Both the vendor and extension names must start with a lower or upper case letter, followed by letters and numbers
+    only. **Underscores, dashes and other characters are not permitted.** It is perfectly fine to have an extension
+    named ``iamanextension``.
+
+
+Composer JSON
 =============
 
-The content of the ``composer.json`` file may look very technical, but you only
-have to change a few lines. The information about the extension is stored as a
-JSON array. The details are explained after the sample, but now let's have a
-look at the complete file:
+Every extension requires a metadata file named ``composer.json`` in order for phpBB to identify your extension.
+This file contains basic information about an extension as well its dependencies. It is written using the JSON format
+and must be stored in the root folder of the extension, e.g.: ``phpBB/ext/acme/demo/composer.json``.
+
+The information in ``composer.json`` will be used by the Extensions Manager in the ACP.
+The details of the meta data are explained below the sample, but for now let's have a look at the complete file:
 
 .. code-block:: json
 
@@ -52,13 +62,16 @@ look at the complete file:
         "homepage": "https://github.com/nickvergessen/phpbb-ext-acme-demo",
         "version": "0.1.0",
         "time": "2013-11-05",
+        "keywords": ["phpbb", "extension", "acme", "demo"],
         "license": "GPL-2.0",
-        "authors": [{
+        "authors": [
+            {
                 "name": "Nickv",
                 "email": "nickvergessen@localhost",
                 "homepage": "https://github.com/nickvergessen/",
                 "role": "Lead Developer"
-            }],
+            }
+        ],
         "require": {
             "php": ">=5.3.3",
             "composer/installers": "~1.0"
@@ -74,341 +87,95 @@ look at the complete file:
         }
     }
 
+.. note::
+
+    It is important to remember that the last item or object in any JSON array must not contain a trailing comma.
+
 .. csv-table::
    :header: "Field", "Content"
    :delim: |
 
-   ``name`` | "Must contain the vendor and extension name, matching the folder
-   structure"
-   ``type`` | ``phpbb-extension`` **must not be changed**
-   ``description`` | "A short description of your extension, may also be empty
-   (but not skipped)"
-   ``homepage`` | "Must contain a valid URL. It is recommended to use the link
+   ``name`` | "The vendor name and extension name, separated by ``/``, matching the folder
+   structure."
+   ``type`` | "The type of package. It should always be ``phpbb-extension``."
+   ``description`` | "A short description of your extension, may be empty
+   (but not skipped)."
+   ``homepage`` *optional* | "A valid URL. It is recommended to use the link
    to the contribution in the customisation database, or to the repository of
    your extension (if you are using a public one like GitHub)."
-   ``version`` | "The version of your extension. You may also use ``-a1``
-   (alpha), ``-b1`` (beta), ``-rc1`` (release candidate) and ``-dev`` suffixes
-   (although you may not submit them to the customisation database.)"
-   ``time`` | "Must contain the release date of this version (date is required,
-   time is optional)"
-   ``license`` | The license must be ``GPL-2.0`` for now
-   ``authors`` | "An array with the authors of the extension.
+   ``version`` | "The version of your extension. This should follow the format of X.Y.Z with an optional suffix
+   of -dev, -patch, -alpha, -beta or -RC."
+   ``time`` *optional* | "The release date of your extension. Must be in YYYY-MM-DD or YYYY-MM-DD HH:MM:SS format."
+   ``keywords`` *optional* | "An array of keywords related to the extension."
+   ``license`` | "The license of the package. This can be either a string or an array of strings.
+   Typically extensions should be licensed under the same GPL-2.0 license as phpBB."
+   ``authors`` | "An array of authors of the extension.
    See `authors`_ for more details."
-   ``require`` | "An array with requirements of the extension.
+   ``require`` | "An array of requirements of the extension.
    See `require`_ for more details."
-   ``require-dev`` | "An array with development requirements of the extension.
+   ``require-dev`` *optional* | "An array of development requirements of the extension.
    See `require-dev`_ for more details."
-   ``extra`` | "An array with additional values of the extension.
+   ``extra`` | "An array of arbitrary extra data.
    See `extra`_ for more details."
 
 authors
 -------
 
-You may have unlimited authors. But you should at least have one.
+You may have unlimited authors. At least have one author is highly recommended.
 
 .. csv-table::
    :header: "Field", "Content"
    :delim: |
 
-   ``name`` | Name of the author
-   ``email`` | Email address of the author
-   ``homepage`` | Must contain one valid URL or be empty
-   ``role`` | "Role can be used to specify what the authors did for the
-   extension (e.g. Developer, Translator, Supporter, ...)"
+   ``name`` | "The name of an author."
+   ``email`` *optional* | "An email address of the author."
+   ``homepage`` *optional* | "A URL pointing to the website of the author."
+   ``role`` *optional* | "Role can be used to specify what the author did for the
+   extension (e.g. Developer, Translator, Supporter, etc.)"
 
 require
 -------
 
-In the ``require`` section you can specify the technical requirements of your
-extension. Examples are the ``php`` version, or
-`third party libraries <https://packagist.org/>`_. Since our demo extension does
-not require any additional library, we only use the PHP version requirement, to
-make sure people have the right PHP version on their server, and composer
-installers for some internal handling. phpBB 3.1 requires PHP 5.3.3 or higher,
-so the version comparison is ``>= 5.3.3``.
+List the dependencies required by the extension, i.e: the PHP version and
+`third party libraries <https://packagist.org/>`_.
+
+.. csv-table::
+   :header: "Field", "Content"
+   :delim: |
+
+   ``php`` | "The minimum-stability version of PHP required by the extension. phpBB 3.1 requires PHP 5.3.3 or higher,
+   so the version comparison is ``>= 5.3.3``."
+   ``composer/installers`` | "Recommended by phpBB for some internal handling."
 
 require-dev
 -----------
 
-In the ``require-dev`` section you can specify the technical requirements of your
-extension, which are only required for development. We use the
-`Extension PreValidation <https://packagist.org/packages/phpbb/epv>`_ Tool from
-the phpBB Extensions Team here, to perform some basic validation when running
-our tests on Travis CI in :doc:`tutorial_testing`. Since we always want to have
+In the optional ``require-dev`` section you can list the dependencies of the extension which are only required for
+development. Acme Demo uses the `Extension Pre Validator Tool <https://packagist.org/packages/phpbb/epv>`_ from
+the phpBB Extensions Team to perform some basic validation when running
+tests on Travis CI (see :doc:`tutorial_testing`). Since we always want to have
 the newest version, we require ``dev-master``.
 
 extra
 -----
 
-This section contains only additional information and is up to free usage in
-terms of the composer-specification. However, phpBB is using two special entries
-in this array for extensions:
+This section can contain virtually any arbitrary data according to the composer-specification. However, phpBB requires
+ two
+special entries in this array for extensions:
 
 .. csv-table::
    :header: "Field", "Content"
    :delim: |
 
-   ``display-name`` | "Display name of the extension (can be different than the
-   folder name)"
-   ``soft-require`` | "Soft requirements are basically like `require`_. The only
-   difference is that composer does not know that these requirements exist.
-   This allows us, for example, to compare the phpBB version, although there
-   might not be a phpBB package with the specified version. In this case we
-   require any 3.1 version. This can be done, by prefixing it with a ``~``:
-   ``""phpbb/phpbb"": ""~3.1""``"
+   ``display-name`` | "The name of your extension, e.g.: Acme Demo Extension."
+   ``soft-require`` | "The minimum-stability version of phpBB required by the extension. In this case we require
+   any 3.1 version, which is done by prefixing it with a ``~``: ``""phpbb/phpbb"": ""~3.1""``."
 
-Enable extension
-================
+.. seealso::
 
-After you filled the ``composer.json`` with the content as described above, you
-can go to the "Administration Control Panel" (ACP) > "Customise" > "Extensions"
-and enable the extension.
+    A complete explanation of all JSON schema fields available in a composer.json file can be found here: https://getcomposer.org/doc/04-schema.md
 
-HTML Events
-===========
+    More information on specifying package version constraints can be found here: https://getcomposer.org/doc/articles/versions.md#basic-constraints
 
-So far, all we have done is create an extension that does nothing. So let's
-create some code to generate output and verify that the extension is working.
-
-Listening to an event
----------------------
-
-In order to add new HTML elements to the output, we need to create a listener,
-which is then included by phpBB when the event happens. You can find a full list
-of events in the `Event list <https://wiki.phpbb.com/Event_List>`_ on the Wiki.
-
-For now we will use the ``overall_header_navigation_prepend`` event, to add a
-new link before the existing links in the navigation bar.
-
-In order to "subscribe" to an event, you need to create an HTML file that is
-named the same as the event. So in our case the file is named
-``overall_header_navigation_prepend.html``. The file needs to be inside an
-``event`` subfolder of the template of your style: e.g.
-``styles/prosilver/template/event/overall_header_navigation_prepend.html``.
-
-You can also put the file into ``styles/all/template/event/``. This will make
-phpBB include the listener (``overall_header_navigation_prepend.html``) in all
-styles.
-
-Inside the listener, we create a simple list element, with a link and a
-description:
-
-.. code-block:: html
-
-    <li class="small-icon icon-faq no-bulletin">
-        <a href="{U_DEMO_PAGE}">
-            {L_DEMO_PAGE}
-        </a>
-    </li>
-
-.. note::
-
-    The template syntax is explained on the
-    `Template Syntax <https://wiki.phpbb.com/Tutorial.Template_syntax#Syntax_elements>`_
-    Wiki page.
-
-After saving the file, you should see a new link at the top left, with the icon
-of the FAQ link and the text ``DEMO_PAGE``. We will fix the link description in
-the next section.
-
-.. note::
-
-    If the link does not show up for you, you might need to purge the cache on
-    the front page of the ACP. You should also make sure that
-    "Recompile stale style components" is enabled in the "General" > "Load
-    settings" section, to avoid having to purge the cache each time you modify
-    an existing template/style file.
-
-Triggering an event (advanced)
-------------------------------
-
-You can also include template events in your own template files, so other
-extensions can manipulate the output of your extension. You can do this by
-adding ``<!-- EVENT acme_demo_myevent -->`` in the desired location. Other
-extensions could then create a ``acme_demo_myevent.html`` file to listen to this
-event.
-
-.. warning::
-
-    You must always prefix your event names with your vendor and extension name.
-
-.. warning::
-
-    It is not recommended to reuse existing event names in different locations.
-    This should only be done if the code (nested HTML elements) around the
-    event is the same for both locations. Also think about other extensions: do
-    they always want to listen to both places, or just one? In case of doubt:
-    use a new event and unique.
-
-PHP Events
-==========
-
-In order to fix the description of the link in the previous section, we are
-going to load a language file that contains the ``DEMO_PAGE`` language variable
-we used.
-
-Creating the language file
---------------------------
-
-The language file should be placed in the ``language/`` folder of the extension.
-Since this tutorial is in English, we only add the English language file:
-``language/en/demo.php``
-
-.. code-block:: php
-
-    <?php
-    /**
-     *
-     * This file is part of the phpBB Forum Software package.
-     *
-     * @copyright (c) phpBB Limited <https://www.phpbb.com>
-     * @license GNU General Public License, version 2 (GPL-2.0)
-     *
-     * For full copyright and license information, please see
-     * the docs/CREDITS.txt file.
-     *
-     */
-
-    if (!defined('IN_PHPBB'))
-    {
-        exit;
-    }
-
-    if (empty($lang) || !is_array($lang))
-    {
-        $lang = array();
-    }
-
-    $lang = array_merge($lang, array(
-        'DEMO_PAGE'			=> 'Demo',
-    ));
-
-.. warning::
-
-    The check for ``IN_PHPBB`` is mandatory for all php files, which contain
-    code that is immediately executed:
-
-    .. code-block:: php
-
-        if (!defined('IN_PHPBB'))
-        {
-            exit;
-        }
-
-Loading the language file
--------------------------
-
-Now there is a bit of magic involved in this section, but you may ignore the
-details, if you just want to get the demo working.
-
-Similar to the `HTML Events`_ phpBB also has PHP events. Those can be used, to
-execute PHP code. In order to subscribe to a PHP event, you need to create a
-class that extends Symfony's
-``Symfony\Component\EventDispatcher\EventSubscriberInterface`` interface. This
-interface contains a static method ``getSubscribedEvents()`` which returns an
-array, with ``'name of the event' => 'name of the method to call'`` pairs.
-In case when the event is triggered, the method will be called, with an array
-argument, containing all variables that are supported by the PHP event.
-
-A full list of the supported PHP events, including the version they have been
-added in, can be found in the Wiki
-`Event list <https://wiki.phpbb.com/Event_List>`_.
-
-Writing the listener
-++++++++++++++++++++
-
-Since we want to load the new language file everywhere, we subscribe to the
-``core.user_setup`` event. In the listener method we add our language file to
-the ``lang_set_ext`` array. phpBB will then load the file automatically:
-
-.. code-block:: php
-
-    <?php
-    /**
-     *
-     * This file is part of the phpBB Forum Software package.
-     *
-     * @copyright (c) phpBB Limited <https://www.phpbb.com>
-     * @license GNU General Public License, version 2 (GPL-2.0)
-     *
-     * For full copyright and license information, please see
-     * the docs/CREDITS.txt file.
-     *
-     */
-
-    namespace acme\demo\event;
-
-    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-
-    /**
-     * Event listener
-     */
-    class main_listener implements EventSubscriberInterface
-    {
-        static public function getSubscribedEvents()
-        {
-            return array(
-                'core.user_setup' => 'load_language_on_setup',
-            );
-        }
-
-        public function load_language_on_setup($event)
-        {
-            $lang_set_ext = $event['lang_set_ext'];
-            $lang_set_ext[] = array(
-                'ext_name' => 'acme/demo',
-                'lang_set' => 'demo',
-            );
-            $event['lang_set_ext'] = $lang_set_ext;
-        }
-    }
-
-.. warning::
-
-    Due to a limitation in PHP itself, you can not add entries to arrays of the
-    event argument. In order to do that you need to create a copy of the array,
-    add the value and then reassign the new array to the event array.
-
-Registering the listener
-++++++++++++++++++++++++
-
-To have phpBB execute our listener, we need to register the event listener, so
-phpBB knows, how to create it.
-
-This is done by creating a ``config/services.yml`` file. ``#`` is used to start
-inline comments in ``yaml`` files.
-
-.. code-block:: yaml
-
-    services:
-        acme.demo.listener:       # name of the service you want to register
-            class: acme\demo\event\main_listener
-            tags:
-                - { name: event.listener }
-
-.. caution::
-
-    ``yaml`` is indentation sensitive, so make sure that each line that is a
-    child of the previous line is indented with four additional spaces and do
-    **not use tabs**.
-
-The first line tells phpBB that a list of services is being registered. On the
-next line we specify the name of the service.
-
-.. warning::
-
-    Similar to event names your service names should be prefixed with your
-    vendor and extension name.
-
-The ``class`` attribute must contain the namespace and class name of the service
-we want to register. The class and namespace depends on the file's location,
-whereby the ``ext/`` is the root of the name. So the our file
-``ext/acme/demo/event/main_listener.php`` has the namespace ``acme\demo\event``
-and class name ``main_listener``. The full name of the class is therefor
-``acme\demo\event\main_listener`` which is what we need to specify here.
-
-In the ``tags`` list we tell phpBB that the defined service is an event
-listener.
-
-After purging the cache in the ACP, the description of the link in the
-navigation bar should now be ``Demo`` instead of ``DEMO_PAGE``.
+So far, your extension has no functionality yet. Continue on to the next sections to learn more about how to write
+an extension that will do something useful.

--- a/development/extensions/tutorial_events.rst
+++ b/development/extensions/tutorial_events.rst
@@ -131,7 +131,7 @@ to PHP events in phpBB's codebase. The listener class must be created in the
 `event/` subdirectory of the extension directory or it will not work. It must also
 conform to the following requirements:
 
-* Follow extension class naming conventions: ``vendor_extname_event_subscribername.php``.
+* Follow extension class name-spacing conventions: ``vendor\extname\event\subscribername.php``.
 * Implement Symfony's ``Symfony\Component\EventDispatcher\EventSubscriberInterface``
   interface.
 * Use the static method ``getSubscribedEvents()`` to subscribe methods in the listener

--- a/development/extensions/tutorial_events.rst
+++ b/development/extensions/tutorial_events.rst
@@ -41,7 +41,7 @@ use, and place it in the ``event/`` subdirectory of a style’s template folder.
 
 For example, we will use the ``overall_header_navigation_prepend`` event to add a
 new link before the existing links in the board's navigation bar. The listener
-will be located at:
+for this event will be:
 
 ::
 
@@ -50,7 +50,7 @@ will be located at:
 .. tip::
 
     If you want a template listener to be used by all styles, it should be placed
-    in the ``all/`` style directory, e.g.: ``vendor/extname/styles/all/template/event/``.
+    in the ``all/`` style directory, e.g. ``vendor/extname/styles/all/template/event/``.
     This helps prevent code duplication and eases style file management.
 
     The prosilver and subsilver2 directories should be used for template files that
@@ -58,7 +58,7 @@ will be located at:
     requires additional customisation to maintain compatibility, a folder for that
     style should be included with those template files.
 
-    To add ACP template listeners, place the those files in ``vendor/extname/adm/style/event/``.
+    To add ACP template listeners, place those files in ``vendor/extname/adm/style/event/``.
 
 Inside the template listener, we will create a nav-bar link. This consists of a
 simple list element, with a link and a description:
@@ -71,8 +71,8 @@ simple list element, with a link and a description:
         </a>
     </li>
 
-Once the template listener has been saved, you should be able to see the new link
-in the top-left of the board's nav-bar, with the icon of the FAQ link and the
+Once the template listener has been created, you should be able to see the new link
+in the board's nav-bar, with the icon of the FAQ link and the
 text ``DEMO_PAGE``. We will fix the link text in the next section.
 
 .. tip::
@@ -82,11 +82,11 @@ text ``DEMO_PAGE``. We will fix the link text in the next section.
     ``config.php`` file, which will force the template engine to always
     look for template listeners when a page is being rendered.
 
-It's also important to understand that when phpBB compiles the templates,
+It's important to understand that when phpBB compiles the templates,
 there is no current system for determining the priority in which template
 listeners from different extensions subscribed to the same event are
 compiled. In rare cases some extensions could cause a conflict, in which case
-the recommendation is for the extension authors to work out a solution for their
+the recommendation is for the extension authors to work together on a solution for their
 conflicting template listeners.
 
 
@@ -94,15 +94,15 @@ PHP Core Events & Listeners
 ===========================
 
 Events allow extensions to execute code in many locations within core phpBB code,
-without modifying any of the code. That way extensions can add features, remove
-functionality or modify behaviour easily and while maintaining easy compatibility
-and simple update procedures.
+without modifying any of the code. That way extensions can easily add features,
+remove functionality or modify behaviour, while maintaining compatibility and
+simple update procedures.
 
 Terminology
 -----------
 
 Events
-    Events are triggered in various places of the core phpBB code. Listeners in
+    Events are dispatched at various places in the core phpBB code. Listeners in
     extensions subscribe to these events. They are able to execute code whenever
     the respective event has occurred. An alternative name for events is “hook locations”.
 
@@ -126,9 +126,9 @@ file that contains the ``DEMO_PAGE`` language key so that our nav-bar link will
 display with the correct text.
 
 To do so, we need to create a PHP event listener class (a.k.a. subscriber class).
-This class includes a set of listeners as methods, each of which can *subscribe*
+This class includes a set of listener methods, each of which can *subscribe*
 to PHP events in phpBB's codebase. The listener class must be created in the
-`event/` subdirectory of the extension directory or it will not work. It must also
+``event/`` subdirectory of the extension directory or it will not work. It must also
 conform to the following requirements:
 
 * Follow extension class name-spacing conventions: ``vendor\extname\event\subscribername.php``.
@@ -138,7 +138,7 @@ conform to the following requirements:
   to specific events, the keys of which contain event names and the values of which
   contain listener function names.
 
-In the Acme Demo extension, we want to load our language file everywhere. Therefor
+In the Acme Demo extension, we want to load our language file everywhere. Therefore
 we will subscribe a listener function to phpBB's ``core.user_setup`` event:
 
 .. code-block:: php
@@ -182,16 +182,19 @@ we will subscribe a listener function to phpBB's ``core.user_setup`` event:
 
 So what is the ``main_listener.php`` class above actually doing?
 
-The ``getSubscribedEvents()`` method is subscribing our function
+The ``getSubscribedEvents()`` method is subscribing our listener function
 ``load_language_on_setup()`` to the event named ``core.user_setup``. This means
 that when this event occurs, our function will execute.
 
-.. note::
+.. tip::
 
     You can assign multiple listener functions to a single event using an array:
-    ``'core.user_setup' => array(array('foo_method'), array('bar_method'))``
 
-The ``load_language_on_setup()`` method is our listener method and it simply adds
+    .. code-block:: php
+
+        'core.user_setup' => array(array('foo_method'), array('bar_method'))
+
+The ``load_language_on_setup()`` listener method simply adds
 our language file to phpBB's language data array. Generally speaking, a listener
 is simply a public function in the subscriber class, referred to in the array
 returned by ``getSubscribedEvents()``. It takes one argument, ``$event``. This
@@ -209,7 +212,7 @@ variable by adding Acme Demo's language file to it.
 Registering the listener
 ------------------------
 
-To have phpBB autoload and execute our event listener, we need to create a
+To have phpBB autoload and execute our event listener class, we need to create a
 service definition for it. This is done by creating a ``config/services.yml``
 file in the extension:
 
@@ -238,7 +241,7 @@ The ``class`` attribute must contain the name-space and class name of the
 service being registered. The name-space depends on the file's location,
 within the ``ext/`` directory. Thus, the file ``ext/acme/demo/event/main_listener.php``
 has the namespace ``acme\demo\event`` and class name ``main_listener``.
-The full name of the class is therefor ``acme\demo\event\main_listener``
+The full name of the class is therefore ``acme\demo\event\main_listener``
 which is what we need to specify here.
 
 The ``tags`` attribute tells phpBB that the service is an event listener.

--- a/development/extensions/tutorial_events.rst
+++ b/development/extensions/tutorial_events.rst
@@ -1,0 +1,285 @@
+==============================
+Tutorial: Events and Listeners
+==============================
+
+Introduction
+============
+
+phpBB 3.1 introduced a system of events throughout the codebase and template files
+that allow extensions to use listeners to add features, inject code, and modify existing
+functionality and behaviour.
+
+This tutorial explains how to use events and listeners:
+
+ * `Template Events & Listeners`_
+ * `PHP Core Events & Listeners`_
+
+
+.. _template-events-label:
+
+Template Events & Listeners
+===========================
+
+Template events allow extensions to inject code into the template files. Events
+can be found throughout the template structure of phpBB's styles, providing
+multiple useful injection points. A typical template event looks like:
+
+::
+
+    <!-- EVENT event_name_and_position -->
+
+.. seealso::
+
+    View the full list of `Template events <https://wiki.phpbb.com/Event_List#Template_Events>`_ in our Wiki.
+
+Listening for an event
+----------------------
+
+To *subscribe* to a template event, we must create a *listener*, a template file
+with exactly the same name as the identifier of the template event we want to
+use, and place it in the ``event/`` subdirectory of a style’s template folder.
+
+For example, we will use the ``overall_header_navigation_prepend`` event to add a
+new link before the existing links in the board's navigation bar. The listener
+will be located at:
+
+::
+
+    acme/demo/styles/prosilver/template/event/overall_header_navigation_prepend.html
+
+.. tip::
+
+    If you want a template listener to be used by all styles, it should be placed
+    in the ``all/`` style directory, e.g.: ``vendor/extname/styles/all/template/event/``.
+    This helps prevent code duplication and eases style file management.
+
+    The prosilver and subsilver2 directories should be used for template files that
+    must be custom tailored to each style. Similarly, if a 3rd-party style
+    requires additional customisation to maintain compatibility, a folder for that
+    style should be included with those template files.
+
+    To add ACP template listeners, place the those files in ``vendor/extname/adm/style/event/``.
+
+Inside the template listener, we will create a nav-bar link. This consists of a
+simple list element, with a link and a description:
+
+.. code-block:: html
+
+    <li class="small-icon icon-faq no-bulletin">
+        <a href="{U_DEMO_PAGE}">
+            {L_DEMO_PAGE}
+        </a>
+    </li>
+
+Once the template listener has been saved, you should be able to see the new link
+in the top-left of the board's nav-bar, with the icon of the FAQ link and the
+text ``DEMO_PAGE``. We will fix the link text in the next section.
+
+.. tip::
+
+    If the link does not appear, you may need to purge the board cache from
+    the main page of the ACP. You can also enable ``DEBUG_MODE`` in your
+    ``config.php`` file, which will force the template engine to always
+    look for template listeners when a page is being rendered.
+
+It's also important to understand that when phpBB compiles the templates,
+there is no current system for determining the priority in which template
+listeners from different extensions subscribed to the same event are
+compiled. In rare cases some extensions could cause a conflict, in which case
+the recommendation is for the extension authors to work out a solution for their
+conflicting template listeners.
+
+
+PHP Core Events & Listeners
+===========================
+
+Events allow extensions to execute code in many locations within core phpBB code,
+without modifying any of the code. That way extensions can add features, remove
+functionality or modify behaviour easily and while maintaining easy compatibility
+and simple update procedures.
+
+Terminology
+-----------
+
+Events
+    Events are triggered in various places of the core phpBB code. Listeners in
+    extensions subscribe to these events. They are able to execute code whenever
+    the respective event has occurred. An alternative name for events is “hook locations”.
+
+Listeners
+    Listeners are triggered by events. They are methods that can process incoming
+    data and manipulate variables in the scope of the event. So they can change phpBB's
+    behaviour, add new functionality or if used in the context of templates, modify the
+    output. Numerous listeners form part of a subscriber. An alternative name for
+    listeners is "hooks".
+
+.. seealso::
+
+    View the full list of supported `PHP events <https://wiki.phpbb.com/Event_List>`_ in our Wiki.
+
+The event listener
+------------------
+
+In the previous section we created a template listener that adds a link for the Acme
+Demo extension to phpBB's nav-bar. We will now use PHP events to load a language
+file that contains the ``DEMO_PAGE`` language key so that our nav-bar link will
+display with the correct text.
+
+To do so, we need to create a PHP event listener class (a.k.a. subscriber class).
+This class includes a set of listeners as methods, each of which can *subscribe*
+to PHP events in phpBB's codebase. The listener class must be created in the
+`event/` subdirectory of the extension directory or it will not work. It must also
+conform to the following requirements:
+
+* Follow extension class naming conventions: ``vendor_extname_event_subscribername.php``.
+* Implement Symfony's ``Symfony\Component\EventDispatcher\EventSubscriberInterface``
+  interface.
+* Use the static method ``getSubscribedEvents()`` to subscribe methods in the listener
+  to specific events, the keys of which contain event names and the values of which
+  contain listener function names.
+
+In the Acme Demo extension, we want to load our language file everywhere. Therefor
+we will subscribe a listener function to phpBB's ``core.user_setup`` event:
+
+.. code-block:: php
+
+    <?php
+
+    namespace acme\demo\event;
+
+    use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+    class main_listener implements EventSubscriberInterface
+    {
+        /**
+         * Assign functions defined in this class to event listeners in the core
+         *
+         * @return array
+         */
+        static public function getSubscribedEvents()
+        {
+            return array(
+                'core.user_setup' => 'load_language_on_setup',
+            );
+        }
+
+        /**
+         * Load the Acme Demo language file
+         *     acme/demo/language/en/demo.php
+         *
+         * @param \phpbb\event\data $event The event object
+         */
+        public function load_language_on_setup($event)
+        {
+            $lang_set_ext = $event['lang_set_ext'];
+            $lang_set_ext[] = array(
+                'ext_name' => 'acme/demo',
+                'lang_set' => 'demo',
+            );
+            $event['lang_set_ext'] = $lang_set_ext;
+        }
+    }
+
+So what is the ``main_listener.php`` class above actually doing?
+
+The ``getSubscribedEvents()`` method is subscribing our function
+``load_language_on_setup()`` to the event named ``core.user_setup``. This means
+that when this event occurs, our function will execute.
+
+.. note::
+
+    You can assign multiple listener functions to a single event using an array:
+    ``'core.user_setup' => array(array('foo_method'), array('bar_method'))``
+
+The ``load_language_on_setup()`` method is our listener method and it simply adds
+our language file to phpBB's language data array. Generally speaking, a listener
+is simply a public function in the subscriber class, referred to in the array
+returned by ``getSubscribedEvents()``. It takes one argument, ``$event``. This
+parameter allows you to access and modify the variables that are given to the
+event from the core code. In this case we are modifying the ``lang_set_ext``
+variable by adding Acme Demo's language file to it.
+
+.. note::
+
+    Note how the ``lang_set_ext`` event variable is first copied by assigning
+    it to a local variable, then modified, and then copied back. This shortcut
+    does not work: ``$event['foo']['bar'] = $baz;`` This is because the event
+    variables are overloaded, which is a limitation in PHP.
+
+Registering the listener
+------------------------
+
+To have phpBB autoload and execute our event listener, we need to create a
+service definition for it. This is done by creating a ``config/services.yml``
+file in the extension:
+
+.. code-block:: yaml
+
+    services:
+        acme.demo.listener:
+            class: acme\demo\event\main_listener
+            tags:
+                - { name: event.listener }
+
+.. warning::
+
+    YAML files are indentation sensitive. They require an indentation size
+    of 4 spaces per indent, **do not use tabs**.
+
+The first line tells phpBB that a list of services is being registered. On
+the next line we specify the name of the service, which is for our event
+listener in this case.
+
+.. important::
+
+    Service names must be prefixed with your vendor and extension name.
+
+The ``class`` attribute must contain the name-space and class name of the
+service being registered. The name-space depends on the file's location,
+within the ``ext/`` directory. Thus, the file ``ext/acme/demo/event/main_listener.php``
+has the namespace ``acme\demo\event`` and class name ``main_listener``.
+The full name of the class is therefor ``acme\demo\event\main_listener``
+which is what we need to specify here.
+
+The ``tags`` attribute tells phpBB that the service is an event listener.
+
+Once the services YAML file has been created (or modified), phpBB's cache
+needs to be purged. After purging the cache in the ACP, the description of
+the link in the navigation bar should now display ``Demo`` instead of
+``DEMO_PAGE``.
+
+.. note::
+
+    phpBB’s core PHP and template files have been prepared with dozens of event locations.
+    However, if there are no events where your extension may need one, the phpBB development
+    team welcomes event requests at the
+    `area51.com Event Requests <http://area51.phpbb.com/phpBB/viewforum.php?f=111>`_ forum.
+
+Prioritising event listeners (optional)
+---------------------------------------
+
+Sometimes different extensions can run into problems when competing for use of
+the same PHP core events. In trying to resolve these issues, the extension
+developer may want to prioritise their extension over others, so that their
+extension will be triggered before other extensions.
+
+In such cases, the ``getSubscribedEvents()`` method provides an argument for
+setting a priority for event listener methods. For example:
+
+.. code-block:: php
+
+    static public function getSubscribedEvents()
+    {
+        return array(
+            'core.user_setup' => array('foo_method', $priority)
+        );
+    }
+
+In this example, ``$priority`` is an integer, the value of which defaults to 0.
+Setting this integer to higher values equals more importance and therefore that
+listener will be triggered earlier than others subscribed to this event.
+
+We have now used events and listeners to modify phpBB and insert a nice link into
+the nav-bar. However, the link still does not work yet. Continue on to the next
+section to learn how to use controllers and routing to make our nav-bar link open
+up a custom user facing page.


### PR DESCRIPTION
Update the Basics and Events page. Split it up into two pages.

These docs also contain info copied from the wiki pages:
https://wiki.phpbb.com/Extension_meta_data
https://wiki.phpbb.com/Developing_Extensions
https://wiki.phpbb.com/Category:Events_and_Listeners
https://wiki.phpbb.com/Add_Events
https://wiki.phpbb.com/Add_Listeners
https://wiki.phpbb.com/Add_Template_Listeners

This PR is part of the extension documentation overhaul:
Part 0 - Refactor index links #83 
Part 2 - Key Concepts #84 
Part 3 - Controllers #85 
Part 4 - Modules and Migrations #86 
Part 5 - Permissions #87 
Part 6 - Authentication #88 
Part 7 - Advanced Lessons #89 
PR Misc. #90 

This is for all doc branches (3.1 & 3.2)