### PR TITLE
Update AuthenticationProvider Documentation

### DIFF
--- a/development/extensions/tutorial_authentication.rst
+++ b/development/extensions/tutorial_authentication.rst
@@ -110,7 +110,7 @@ The service file
 ++++++++++++++++
 For proper `dependency injection <https://wiki.phpbb.com/Dependency_Injection_Container>`_
 the provider must be added to ``services.yml``. The name of the service 
-must be in the form of ``auth.provider.``<service name> in order for phpBB to register it.
+must be in the form of ``auth.provider.<service name>`` in order for phpBB to register it.
 The arguments are those of the provider's constructor and may be empty if no arguments are
 necessary. The provider must be tagged with ``{ name: auth.provider }`` in order
 for the class to be made available in phpBB.

--- a/development/extensions/tutorial_authentication.rst
+++ b/development/extensions/tutorial_authentication.rst
@@ -110,7 +110,7 @@ The service file
 ++++++++++++++++
 For proper `dependency injection <https://wiki.phpbb.com/Dependency_Injection_Container>`_
 the provider must be added to ``services.yml``. The name of the service 
-must be in the form of auth.provider.<service name> in order for phpBB to register it.
+must be in the form of ``auth.provider.``<service name> in order for phpBB to register it.
 The arguments are those of the provider's constructor and may be empty if no arguments are
 necessary. The provider must be tagged with ``{ name: auth.provider }`` in order
 for the class to be made available in phpBB.

--- a/development/extensions/tutorial_authentication.rst
+++ b/development/extensions/tutorial_authentication.rst
@@ -109,12 +109,11 @@ authentication provider class is show below:
 The service file
 ++++++++++++++++
 For proper `dependency injection <https://wiki.phpbb.com/Dependency_Injection_Container>`_
-the provider must be added to ``services.yml``. The arguments are those
-of the provider's constructor and may be empty if no arguments are
+the provider must be added to ``services.yml``. The name of the service 
+must be in the form of auth.provider.<service name> in order for phpBB to register it.
+The arguments are those of the provider's constructor and may be empty if no arguments are
 necessary. The provider must be tagged with ``{ name: auth.provider }`` in order
 for the class to be made available in phpBB.
-The service file, the name of the service, must also be in the form of
-``auth.provider.<service name>`` in order for phpBB to properly recognise it.
 
 .. code-block:: yaml
 

--- a/development/extensions/tutorial_authentication.rst
+++ b/development/extensions/tutorial_authentication.rst
@@ -113,6 +113,8 @@ the provider must be added to ``services.yml``. The arguments are those
 of the provider's constructor and may be empty if no arguments are
 necessary. The provider must be tagged with ``{ name: auth.provider }`` in order
 for the class to be made available in phpBB.
+The service file, the name of the service, must also be in the form of
+``auth.provider.<service name>`` in order for phpBB to properly recognise it.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Please take a look at my comment at https://www.phpbb.com/community/posting.php?mode=quote&f=461&p=14577286#pr14577276

I created my authentication provider and named it eg. "myext.authentication.MyAuthenticationProvider".
But my authentication provider will not be found.
The authentication provider service name has to start with "auth.provider." e.g. "auth.provider.MyAuthenticationProvider".
That check is hard coded in phpBB file "auth/provider_collection" method "get_provider" of v3.1.10.
If service name does not start with "auth.provider" the default provider "db" will be used. 

Can you please verify?

Greetz Anthony