### PR TITLE
fix css coding guidelines links

### DIFF
--- a/development/development/coding_guidelines.rst
+++ b/development/development/coding_guidelines.rst
@@ -22,10 +22,10 @@ available which will show you when you violate these standards.
 CSS & SCSS Linting
 ------------------
 
-We use `stylelint <https://stylelint.io/>` for checking the quality, linting,
+We use `stylelint <https://stylelint.io/>`_ for checking the quality, linting,
 and ensuring consistent CSS code standards. There is a .stylelintrc
 file in the root of the project, and your editor probably has a plugin available
 which will show you when you violate these standards.
 
 We employ a set of standards loosely based on the following widely used
-`CSS Guidelines <http://cssguidelin.es/>`
+`CSS Guidelines <http://cssguidelin.es/>`_


### PR DESCRIPTION
Fix the links in the CSS coding guidelines section