### PR TITLE
Fix the description of using add_lang() method

### DIFF
--- a/development/language/usage.rst
+++ b/development/language/usage.rst
@@ -97,7 +97,7 @@ Loading from an extension
 
 To load a file from an extension
 you need to use ``phpbb\language\language::add_lang()`` which takes
-the vendor + extension name as first argument and the array of language files as
+the array of language files as a first argument and the vendor + extension name as
 a second argument.
 
 .. code-block:: php


### PR DESCRIPTION
Currently description says that `phpbb\language\language::add_lang()` takes the vendor + extension name as first argument and the array of language files as a second argument while it should be the opposite as shown in examples right below the description.