### PR TITLE
Add custom style for phpBB w/out fixed width

### DIFF
--- a/development/_static/css/phpbb.css
+++ b/development/_static/css/phpbb.css
@@ -1,0 +1,20 @@
+.wy-side-nav-search {
+    background-color: #009BDF;
+}
+
+.wy-side-nav-search>div.version {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.wy-nav-content {
+    max-width: none; /* use max-width: 800px for button navigation, not content */
+}
+
+.wy-table-responsive table td,
+.wy-table-responsive table th {
+    white-space: normal;
+}
+
+.rst-footer-buttons {
+    max-width: 800px;
+}

--- a/development/conf.py
+++ b/development/conf.py
@@ -124,6 +124,11 @@ html_context = dict(
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
+# Additional CSS files to include
+html_css_files = [
+    'css/phpbb.css',
+]
+
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
 #html_title = None


### PR DESCRIPTION
Adds a simple custom stylesheet for phpBB. Biggest change is getting rid of the max-width while keeping the navigation buttons inside this max-width and adjusting the left menu header to match our colors.
This should also enable adding the event list from the wiki to the documentation.

Full page:
![image](https://user-images.githubusercontent.com/394418/113619066-ccab5100-9658-11eb-95a9-8abdd6e07c12.png)

With some text etc:
![image](https://user-images.githubusercontent.com/394418/113619131-e2b91180-9658-11eb-9709-db5318d20ca6.png)

Smartphone view:
![image](https://user-images.githubusercontent.com/394418/113619185-f5cbe180-9658-11eb-818b-a676e496586e.png)

On smaller resolutions:
![image](https://user-images.githubusercontent.com/394418/113619267-13994680-9659-11eb-9bee-b0d5098242cb.png)
