### PR TITLE
Fix title subsection conventions and errors

### DIFF
--- a/development/db/dbal.rst
+++ b/development/db/dbal.rst
@@ -50,7 +50,7 @@ Example using :class:`config.php`:
     unset($dbpasswd);
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Usage"
@@ -116,7 +116,7 @@ Example:
     $result = $db->sql_query($sql);
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: #
@@ -156,7 +156,7 @@ Example:
     $db->sql_query($sql);
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: #
@@ -180,7 +180,7 @@ Example:
 
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: |
@@ -205,7 +205,7 @@ Example:
     		AND post_text = '" . $db->sql_escape($string) . "'";
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: |
@@ -221,7 +221,7 @@ Defined in the base driver (``_sql_like_expression`` is defined in the specific 
 The ``sql_not_like_expression`` is identical to ``sql_like_expression`` apart from that it builds a NOT LIKE statement.
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: |
@@ -229,11 +229,11 @@ Parameters
    Expression | The expression to use. Every wildcard is escaped, except $db->get_any_char() and $db->get_one_char()
 
 get_one_char
-++++++++++++
+^^^^^^^^^^^^
 Wildcards for matching exactly one (``_``) character within LIKE expressions.
 
 get_any_char
-++++++++++++
+^^^^^^^^^^^^
 Wildcards for matching any (``%``) character within LIKE expressions
 
 Example:
@@ -267,7 +267,7 @@ Example:
     $result = $db->sql_query_limit($sql, 10);
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: |
@@ -296,7 +296,7 @@ Example:
 
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: |
@@ -321,7 +321,7 @@ Example:
 
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: |
@@ -357,7 +357,7 @@ Example:
 
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: |
@@ -418,7 +418,7 @@ Example:
 
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: #
@@ -433,7 +433,7 @@ Returns an array with the result of using the ``sql_fetchrow`` method on every r
 
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: #
@@ -471,7 +471,7 @@ Example with a while-loop:
 
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: #
@@ -484,7 +484,7 @@ Seeks to given row number. The row number is zero-based. Defined in the specific
 
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: #
@@ -514,7 +514,7 @@ Example:
 
 
 Parameters
-++++++++++
+^^^^^^^^^^
 .. csv-table::
    :header: "Parameter", "Usage"
    :delim: #

--- a/development/development/git.rst
+++ b/development/development/git.rst
@@ -22,7 +22,7 @@ phpBB Repository
 ----------------
 
 Forking and Cloning
-+++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^
 To contribute to phpBB development, you should sign up for a
 `GitHub <https://github.com>`_ user account if you don't already have one.
 
@@ -35,7 +35,7 @@ Clone your fork of phpBB's repository to your computer:
 See `Set Up Git <https://help.github.com/articles/set-up-git>`_ for help on setting up Git.
 
 Branches
-++++++++
+^^^^^^^^
 - `master <http://github.com/phpbb/phpbb/tree/master>`_ - The latest unstable development version with new features etc.
 - `3.3.x <http://github.com/phpbb/phpbb/tree/3.3.x>`_ - Development branch of the 3.3 line. Bug fixes and minor feature changes are applied here.
 - `3.2.x <http://github.com/phpbb/phpbb/tree/3.2.x>`_ - Development branch of the 3.2 line. Bug fixes and minor feature changes are applied here.
@@ -44,7 +44,7 @@ Branches
 - `2.0.x <http://github.com/phpbb/phpbb/tree/2.0.x>`_ - Development branch of the deprecated 2.0 line.
 
 Tags
-++++
+^^^^
 Tags are released versions. Stable ones get merged into the master branch.
 
 - release-3.Y.Z-aX - Alpha release X of the 3.Y.Z line.
@@ -58,7 +58,7 @@ will be merged into higher branches, including master. All feature development
 should take place in master. Read more about the workflow in the next section.
 
 How to contribute?
-++++++++++++++++++
+^^^^^^^^^^^^^^^^^^
 When fixing a bug, please post in the `bug tracker <https://tracker.phpbb.com>`__.
 When adding a feature to 3.x post your patch for review in a new topic on the
 `[3.x] Discussion forum <https://area51.phpbb.com/phpBB/viewforum.php?f=81>`__ at
@@ -139,7 +139,7 @@ Review `Forking and Cloning`_.
 Configuration
 -------------
 Git
-+++
+^^^
 Add your Username to Git on your system:
 
 ::
@@ -163,7 +163,7 @@ Add the upstream remote (you can change 'upstream' to whatever you like):
     fork of the phpBB GitHub repo will, by default, use the *origin* remote url.
 
 Composer
-++++++++
+^^^^^^^^
 To be able to run an installation from the repo (and not from a pre-built package) you
 need to run the following shell commands to install phpBB's dependencies.
 
@@ -180,7 +180,7 @@ Ignore any *abandoned package* warnings.
     further information.
 
 Hooks
-+++++
+^^^^^
 The phpBB repository contains some client-side hooks that can aid development. They are
 located in the ``git-tools/hooks`` directory. These hooks do things like preparing and
 validating commit messages, checking for PHP syntax errors. There is a script to set
@@ -214,7 +214,7 @@ Workflow
 ---------
 
 Pulling in upstream changes
-+++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 You will need to merge in changes made to the upstream repository for them to appear in
 your fork, the steps to do this follow. We're assuming you are performing this on the **master**
 branch, but it could be a bug fix branch or a develop release branch, so ensure you are on
@@ -236,7 +236,7 @@ different branches this section refers to later.
 .. image:: images/Phpbb-git-workflow.png
 
 Bug fixing
-++++++++++
+^^^^^^^^^^
 Ensure you are using the correct develop branch (e.g. *3.2.x*) first and not the *master*
 branch. In this example we are using 3.2.x.
 
@@ -252,7 +252,7 @@ branch. In this example we are using 3.2.x.
     git push origin ticket/12345 # Push the branch back to GitHub
 
 Starting a new feature
-++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^
 Ensure you are using the correct develop branch (e.g. *master*) first.  In this example
 we are using master.
 
@@ -267,7 +267,7 @@ we are using master.
     git push origin feature/my-fancy-new-feature # Push the branch back to GitHub
 
 Collaborating with other developers on a feature
-++++++++++++++++++++++++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 You have pushed a new feature to GitHub and another developer has worked on it. This is
 how you can integrate their changes into your own feature branch.
 
@@ -281,7 +281,7 @@ how you can integrate their changes into your own feature branch.
     git push origin feature/my-fancy-new-feature # Push the branch back to GitHub
 
 Merging a feature or bugfix branch
-++++++++++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Once a feature or bug-fix is complete it can be merged back into the master branch. To preserve
 history we never fast-forward such merges. In this example we will merge the bug-fix created
 earlier into 3.2.x. We then merge the changes into 3.3.x and then merge 3.3.x into master
@@ -300,7 +300,7 @@ to keep these branches up to date.
 Additionally the merge.log config setting of Git is set to true, producing a summary of merged commits.
 
 Merging into phpBB repository
-+++++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This *only* applies to Development Team Members. The following steps should be taken when
 merging a topic branch into the phpBB repository.
 

--- a/development/extensions/tutorial_authentication.rst
+++ b/development/extensions/tutorial_authentication.rst
@@ -27,7 +27,7 @@ are part of an extension must provide their own YAML file defining the
 service in addition to all normal requirements of an extension.
 
 The class file
-++++++++++++++
+^^^^^^^^^^^^^^
 The provider class must implement the ``\phpbb\auth\provider\provider_interface`` in order to
 ensure proper functionality. However, it is recommended to extend
 ``\phpbb\auth\provider\base`` so as to not implement unneeded methods and to ensure
@@ -107,7 +107,7 @@ authentication provider class is show below:
     }
 
 The service file
-++++++++++++++++
+^^^^^^^^^^^^^^^^
 For proper `dependency injection <https://wiki.phpbb.com/Dependency_Injection_Container>`_
 the provider must be added to ``services.yml``. The name of the service 
 must be in the form of ``auth.provider.<service name>`` in order for phpBB to register it.
@@ -126,7 +126,7 @@ for the class to be made available in phpBB.
                 - { name: auth.provider }
 
 The template file
-+++++++++++++++++
+^^^^^^^^^^^^^^^^^
 Following the above steps renders the authentication provider visible in the ACP.
 However, to allow an admin to configure your plugin the available fields need to
 be created in order to reach the configuration from the php-auth-provider plugin.
@@ -171,7 +171,7 @@ phpBB. They are copies of the bitly service implementation from phpBB3's
 develop branch.
 
 The Class file
-++++++++++++++
+^^^^^^^^^^^^^^
 .. code-block:: php
 
     <?php
@@ -270,7 +270,7 @@ The Class file
     }
 
 The Service File
-++++++++++++++++
+^^^^^^^^^^^^^^^^
 
 In the service file, the name of the service must be in the form of
 ``auth.provider.oauth.service.<service name>`` in order for phpBB to

--- a/development/extensions/tutorial_migrations.rst
+++ b/development/extensions/tutorial_migrations.rst
@@ -29,7 +29,7 @@ Database changes
 ----------------
 
 Schema changes
-++++++++++++++
+^^^^^^^^^^^^^^
 
 The ``update_schema()`` method is for facilitating schema changes,
 such as adding new tables, columns, keys and indexes.
@@ -42,7 +42,7 @@ We recommend putting schema changes in their own migration.
 Learn more: :doc:`../migrations/schema_changes`.
 
 Data changes
-++++++++++++
+^^^^^^^^^^^^
 
 The ``update_data()`` method is for inserting, updating and dropping
 field data.
@@ -81,7 +81,7 @@ Migration dependencies
 ----------------------
 
 depends_on()
-++++++++++++
+^^^^^^^^^^^^
 
 The ``depends_on()`` method is used to define a migration's dependencies.
 Dependencies tell the migrator what order migrations must be installed in.
@@ -89,7 +89,7 @@ Dependencies tell the migrator what order migrations must be installed in.
 Learn more: :doc:`../migrations/dependencies`.
 
 effectively_installed()
-+++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``effectively_installed()`` method is used primarily to help transition
 from a previous database installer method (such as a MOD that used UMIL)

--- a/development/extensions/tutorial_modules.rst
+++ b/development/extensions/tutorial_modules.rst
@@ -229,7 +229,7 @@ to submit or reset the form. Note that the ``{{ S_FORM_TOKEN }}`` template
 variable is required as part of the `form key`_ security check.
 
 Module language keys
-++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^
 
 Between our module class and template files, we have added some new language keys.
 We can add them to our language array in ``acme/demo/language/en/demo.php``:

--- a/development/extensions/tutorial_notifications.rst
+++ b/development/extensions/tutorial_notifications.rst
@@ -490,7 +490,7 @@ It should return an array with the user identifiers as keys and the notification
 There are various helper functions that help you achieve the desired outcome.
 
 check_user_notification_options
-+++++++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 You can send an array of user identifiers to this function.
 It will then check the available notification methods for each user.
 If the notification type is available in the :abbr:`UCP (User Control Panel)`, it will check the user's preferences.
@@ -498,7 +498,7 @@ Otherwise it will use the default notification methods; the board method and the
 The array that is returned by this function can be used as a return value for find_users_for_notification_.
 
 get_authorised_recipients
-+++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^
 If your notification is for an event within a specific forum, you might want to check the users' authentication.
 This can be done using this function, which will check all users' ``f_read`` permission for the provided ``forum_id``.
 The array that is returned by this function is already put through check_user_notification_options_.
@@ -1082,7 +1082,7 @@ mark_notifications
 ------------------
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"
@@ -1098,7 +1098,7 @@ mark_notifications_by_parent
 ----------------------------
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"
@@ -1119,7 +1119,7 @@ However, there can be times where it is more convenient or accurate to work dire
 For example, when the notifications are listed in the :abbr:`UCP (User Control Panel)` and a user can select specific notifications to be marked as read.
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"

--- a/development/extensions/tutorial_notifications.rst
+++ b/development/extensions/tutorial_notifications.rst
@@ -1034,8 +1034,11 @@ such as when an action occurs that would make your notification irrelevant.
 
 This function is very simple to use, and requires only a few basic parameters:
 
+delete_notifications
+--------------------
+
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"

--- a/development/request/request.rst
+++ b/development/request/request.rst
@@ -89,7 +89,7 @@ If no super global is specified, it will default to the ``REQUEST`` super global
    $session = $request->variable('user_sid', \phpbb\request\request_interface::COOKIE);
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"
@@ -116,7 +116,7 @@ This is a short hand for ``$request->variable('variable', \phpbb\request\request
    }
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"
@@ -203,7 +203,7 @@ The nesting increased with each value provided.
     */
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"
@@ -234,7 +234,7 @@ So for ``<input name="attachment" type="file">`` the variable name is ``attachme
    }
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"
@@ -263,7 +263,7 @@ This function is a shortcut to retrieve the value of the client's HTTP headers.
    }
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"
@@ -289,7 +289,7 @@ It also provides a fallback to ``getenv()`` as some CGI setups may need it.
    $server_port = $request->server('SERVER_PORT', 0);
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"
@@ -329,7 +329,7 @@ Changes which are performed on the super globals directly will **not** have any 
    }
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"
@@ -376,7 +376,7 @@ It will then return all the names *(keys)* that exist for that super global.
    return $hidden;
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"
@@ -414,7 +414,7 @@ It will then return the original array with all the variables for that super glo
    }
 
 Parameters
-++++++++++
+^^^^^^^^^^
 
 .. csv-table::
    :header: "Parameter", "Description"


### PR DESCRIPTION
According to https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html?highlight=sections#sections

Our usage of `+++` is not a proper sub subsection title convention, and should be `^^^`. There was also one title error that is fixed in here too.

This changes literally nothing in the build output of the docs, we just follow the convention with this.