### PR TITLE
Fix float issues from responsive tables

### DIFF
--- a/development/_static/css/phpbb.css
+++ b/development/_static/css/phpbb.css
@@ -10,6 +10,10 @@
     max-width: none; /* use max-width: 800px for button navigation, not content */
 }
 
+.wy-table-responsive {
+    clear: both;
+}
+
 .wy-table-responsive table {
     width: 100%;
 }


### PR DESCRIPTION
Trying to fix this:
<img width="1233" alt="Screen Shot 2021-04-21 at 11 28 57 AM" src="https://user-images.githubusercontent.com/303711/115603243-c5a95300-a294-11eb-9f2b-876035f3e52a.png">
