### PR TITLE
Include PHP 8.1, not open end with 8.2, 8.3 etc.

### DIFF
--- a/documentation/content/en/chapters/quick_start_guide.xml
+++ b/documentation/content/en/chapters/quick_start_guide.xml
@@ -50,7 +50,7 @@
 				</itemizedlist>
 			</listitem>
 			<listitem>
-				<para>PHP 7.2.0+ with support for the database you intend to use.</para>
+				<para>PHP 7.2.0+ up to and including PHP 8.3 with support for the database you intend to use.</para>
 			</listitem>
 			<listitem>
 				<para>getimagesize() function enabled</para>


### PR DESCRIPTION
People tend to use the newest PHP version, which is not always compatible and causes problems.

So let's limit it to 8.1 for now, since 8.2 is not yet officially supported, as we do already in the docs/ dir. 