### PR TITLE
Update links to plural rules and for 3.3.x docs

### DIFF
--- a/development/language/guidelines.rst
+++ b/development/language/guidelines.rst
@@ -143,7 +143,7 @@ If your language pack is denied and then resubmitted, it is placed at the end of
                           index.htm (optional)
                           stylesheet.css
 
-5) Submissions should follow the recommendations in the `3.2 Translation (i18n/L10n) Guidelines`_ as closely as possible, especially the `3.2 Writing style`_.
+5) Submissions should follow the recommendations in the `3.3 Translation (i18n/L10n) Guidelines`_ as closely as possible, especially the `3.3 Writing style`_.
 
 6) All PHP and text files must be encoded in UTF-8 without BOM and a new line at the end of the file. Many modern text editors use this as a default setting, but we recommend checking it in your editor's settings. We recommend you use `Notepad++`_ or `PSPad`_, both lightweight and free.
 
@@ -157,15 +157,15 @@ If your language pack is denied and then resubmitted, it is placed at the end of
 
 11) The contribution screenshot in the Customisations Database should only be the flag of the country where the primary spoken language is that of the language pack. For example, the flag of France for the French language.
 
-12) Revision name in the Customisations Database should be left blank, contain the phpBB package version, and/or package release name (e.g. "**3.2.2 / Bertie’s New Year Resolution**" for 3.2.2).
+12) Revision name in the Customisations Database should be left blank, contain the phpBB package version, and/or package release name (e.g. "**3.3.10 / Bertie’s New Translation**" for 3.3.10).
 
 13) The Demo URL in the Customisations Database must be empty, unless you want to put a link to an international community (`officially`_ listed or not) related to the language of the contribution. For example, https://www.phpbb.nl/ as Demo URL concerning the `Dutch language`_ is allowed.
 
-.. _Customisations Database: https://www.phpbb.com/go/customise/language-packs/3.2
+.. _Customisations Database: https://www.phpbb.com/go/customise/language-packs/3.3
 .. _Language Packs Database: https://www.phpbb.com/languages/
 .. _GNU General Public License 2.0: http://www.opensource.org/licenses/gpl-2.0.php
-.. _3.2 Translation (i18n/L10n) Guidelines: https://area51.phpbb.com/docs/32x/coding-guidelines.html#translation
-.. _3.2 Writing style: https://area51.phpbb.com/docs/32x/coding-guidelines.html#writingstyle
+.. _3.3 Translation (i18n/L10n) Guidelines: https://area51.phpbb.com/docs/33x/coding-guidelines.html#translation
+.. _3.3 Writing style: https://area51.phpbb.com/docs/33x/coding-guidelines.html#writingstyle
 .. _Notepad++: https://notepad-plus-plus.org/
 .. _PSPad: http://www.pspad.com/en/
 .. _officially: https://www.phpbb.com/support/intl/

--- a/development/language/plurals.rst
+++ b/development/language/plurals.rst
@@ -23,7 +23,7 @@ specify them all, and get a loop in there.
 
 As we are not the first developers facing this problem, it was not really hard
 to find a suitable solution. We decided to use the system from
-`Mozilla <https://developer.mozilla.org/en/Localization_and_Plurals>`_.
+`Unicode.org`_, which is e.g. used by Mozilla.
 
 Plural Rules
 ============
@@ -219,3 +219,5 @@ The system is based on
 `Mozilla <https://developer.mozilla.org/en/Localization_and_Plurals>`_, which
 uses the "Plural Rules and Families" from
 `GNU gettext documentation <http://www.gnu.org/software/gettext/manual/html_node/gettext_150.html#Plural-forms>`_.
+
+.. _Unicode.org: https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html

--- a/development/language/validation.rst
+++ b/development/language/validation.rst
@@ -24,12 +24,9 @@ Demo-Link
 ---------
 
 The Demo URL in the Customisation Database must be empty, unless you want to
-put a link to an international community (
-`officially <https://www.phpbb.com/support/intl/>`_ listed or not) related to
-the language of the contribution. For example, http://www.phpbbarabia.com/ as
-Demo URL concerning the
-`Arabic language <https://www.phpbb.com/customise/db/translation/arabic/>`_ is
-allowed.
+put a link to an international community (`officially`_ listed or not) related to
+the language of the contribution. For example, https://www.phpbb.nl/ as Demo
+URL concerning the `Dutch language`_ is allowed.
 
 Package
 -------
@@ -38,8 +35,8 @@ Package
   ``<languagename>_<version>`` folder. The files from above should be placed in
   this folder.
 * Revision name in the `Customisation Database`_ should be left blank, contain
-  the phpBB package version and/or package release name (e.g. ``3.0.12`` /
-  ``Richard 'D¡cky' Foote`` for 3.0.12) for more understanding.
+  the phpBB package version and/or package release name (e.g. ``3.3.10`` /
+  ``Bertie's translation` for 3.3.10) for more understanding.
 
 Package Validation
 ==================
@@ -239,5 +236,7 @@ License
 * All translations must be released under
   `GNU General Public License 2.0 <http://www.opensource.org/licenses/gpl-2.0.php>`_
 
-.. _Customisation Database: https://www.phpbb.com/go/customise/language-packs/3.2
-.. _Language Pack Submission Policy: https://area51.phpbb.com/docs/dev/3.2.x/language/guidelines.html#language-pack-submission-policy
+.. _Customisation Database: https://www.phpbb.com/go/customise/language-packs/3.3
+.. _Language Pack Submission Policy: https://area51.phpbb.com/docs/dev/3.3.x/language/guidelines.html#language-pack-submission-policy
+.. _officially: https://www.phpbb.com/support/intl/
+.. _Dutch language: https://www.phpbb.com/customise/db/translation/dutch_casual_honorifics/


### PR DESCRIPTION
Updated the link to the plural rule info page, because the old Mozilla one is dead. 

In addition some links were still to 3.2 and not implemented properly. 