### PR TITLE
[ticket/1430] fix the order of use and namespace keywords in extension document

### DIFF
--- a/development/extensions/tutorial_controllers.rst
+++ b/development/extensions/tutorial_controllers.rst
@@ -44,9 +44,9 @@ Every controller should contain at least two methods:
 
     <?php
 
-    use \Symfony\Component\HttpFoundation\Response;
-
     namespace acme\demo\controller;
+
+    use \Symfony\Component\HttpFoundation\Response;
 
     class main
     {


### PR DESCRIPTION
Referencing this post I made: https://www.phpbb.com/community/viewtopic.php?p=16009966

While reading the extension documentation I came across a code example of an extension controller. The example has the use keyword before the namespace which is wrong and php throws a fatal error.

Link to the page: https://area51.phpbb.com/docs/dev/3.3.x/extensions/tutorial_controllers.html#controllers

They just need switching around and then they'll work again.

Ticket:
https://tracker.phpbb.com/browse/WEBSITE-1430